### PR TITLE
feat: remove CPU turn guard from spin control

### DIFF
--- a/js/CBallSpinGUI.js
+++ b/js/CBallSpinGUI.js
@@ -48,10 +48,6 @@ function CBallSpinGUI(iX,iY,oParentContainer){
     };
     
     this._onRelease = function(evt){
-        if(((s_iPlayerMode === GAME_MODE_CPU) && (s_oGame.getCurTurn() === 2))){
-            return;
-        }
-        
         var pPoint = _oBg.globalToLocal(evt.stageX, evt.stageY);
         if(distance(new CVector2(evt.stageX, evt.stageY),_vPos)<_iRadius){
             _oToken.x = pPoint.x-_iRadius;


### PR DESCRIPTION
## Summary
- allow players to adjust cue ball spin even during CPU turns by removing the CPU guard in `CBallSpinGUI`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890184bf85c83279187f9ecc1ab81a2