### PR TITLE
Remove CPU shot logic and simplify update

### DIFF
--- a/js/CBall.js
+++ b/js/CBall.js
@@ -94,7 +94,7 @@ function CBall(iType,oParentContainer, oTexture){
         return _oBall3D;
     };
     
-    this.render = function(isCpuTurn){
+    this.render = function(){
         _oContainer.x = _vPos.getX();
         _oContainer.y = _vPos.getY();
     };

--- a/js/CTable.js
+++ b/js/CTable.js
@@ -1,4 +1,4 @@
-function CTable(oParentContainer, oCpuDifficultyParams){
+function CTable(oParentContainer){
     var _bHoldStick;
     var _bReadyForShot;
     var _bBreakShot;
@@ -49,18 +49,13 @@ function CTable(oParentContainer, oCpuDifficultyParams){
     var _fPrevStickAngle;
     var _iPrevState;
     var _iColorCuePrevTrajectory;
-    
-    var _iCpuShotTurn;
-    var _oCpuDifficultyParams;
-    
+
     var _aSoundsInstance;
-    
-    this._init = function(oCpuDifficultyParams){
+
+    this._init = function(){
         _aCbCompleted=new Array();
         _aCbOwner =new Array();
         _aSoundsInstance = new Array();
-     
-        _oCpuDifficultyParams = oCpuDifficultyParams;
         this.reset();
         
         var oSpriteBg = s_oSpriteLibrary.getSprite("pool_table");
@@ -405,7 +400,6 @@ function CTable(oParentContainer, oCpuDifficultyParams){
         _bFirstShot = true;
         _iTimeAnimStick = 0;
         _iCntBallsIntoHoles = 0;
-        _iCpuShotTurn = 0;
         _iShotPoints = 0;
         _iComboShots = 1;
         _iLowestBall = 1;
@@ -1121,11 +1115,7 @@ function CTable(oParentContainer, oCpuDifficultyParams){
     
     this.renderBalls = function(){
         for ( var i = 0; i < _aBalls.length; i++ ){
-            if ( (s_iPlayerMode === GAME_MODE_CPU) && (s_oGame.getCurTurn() === 2) ) {
-                    _aBalls[i].render(true);
-            }else {
-                    _aBalls[i].render(false);
-            }
+            _aBalls[i].render();
 
             if(i=== 8){
                 //_oScenario.move3DBalls(i,_aBalls[i].getPos());
@@ -1139,15 +1129,12 @@ function CTable(oParentContainer, oCpuDifficultyParams){
         _iState = STATE_TABLE_PLACE_CUE_BALL;
         _oContainerUpperBumper.visible = false;
         _oContainerDownBumper.visible = true;
-     
-        var bIsCpu = ((s_iPlayerMode === GAME_MODE_CPU) && (s_oGame.getCurTurn() === 2));
-        if(!bIsCpu){
-            _iPrevState = _iState;
-            _oCueBall.setPos(CUE_BALL_POS.x,CUE_BALL_POS.y);
-            _oStick.setVisible(true);
-            _oHandCueBallDrag.setPos(_oCueBall.getX(), _oCueBall.getY(0));
-            _oHandCueBallDrag.show();
-        }
+
+        _iPrevState = _iState;
+        _oCueBall.setPos(CUE_BALL_POS.x,CUE_BALL_POS.y);
+        _oStick.setVisible(true);
+        _oHandCueBallDrag.setPos(_oCueBall.getX(), _oCueBall.getY(0));
+        _oHandCueBallDrag.show();
     };
     
     this.rotateStick = function(fAngleOffset){
@@ -1501,7 +1488,6 @@ function CTable(oParentContainer, oCpuDifficultyParams){
             }
             
             if(bTurnChanged){
-                _iCpuShotTurn = 0;
                 _iComboShots = 1;
             }
             
@@ -1515,10 +1501,6 @@ function CTable(oParentContainer, oCpuDifficultyParams){
              
             _iShotPoints = 0;
             return bEndGame;
-    };
-    
-    this.isCpuTurn = function (){
-        return (s_iPlayerMode === GAME_MODE_CPU && s_oGame.getCurTurn() === 2);
     };
     
     this.targetting = function(bValue) {
@@ -1566,849 +1548,9 @@ function CTable(oParentContainer, oCpuDifficultyParams){
     
     this.prepareNextTurn = function() {
             _iTimeAnimStick = 0;
-
-            _iCpuShotTurn ++;
-            if(_iCpuShotTurn > _oCpuDifficultyParams.length-1){
-                _iCpuShotTurn = _oCpuDifficultyParams.length-1;
-            }
-            var bEndGame = this.checkTurn();
-            if ( (s_iPlayerMode == GAME_MODE_CPU) && (s_oGame.getCurTurn() === 2) && !bEndGame) {
-                    //m_bTargetting = true;
-
-                    setTimeout(function(){s_oTable.calculateCpuShot();},2000);
-            }
-            
+            this.checkTurn();
             _aBallsInHoleInCurShot.splice(0);
     };
-    
-    //cpu shot
-    this.calculateCpuShot = function(){
-            var bSuccess = true;
-            switch(s_iGameMode){
-                    case GAME_MODE_NINE: {													
-                            var aEdges = _oPhysicsController.getEdges();
-/*
-                            //try to pot nine ball
-                            if(_iLowestBall !== 9){
-                                    var oHole = this.setHoleToAim(_aBalls[_iLowestBall],_aBalls[9], 9,aEdges);					
-                                    if (oHole !== null) {
-                                            var vCollPoint = new CVector2();
-                                            vCollPoint.setV(this.findCollisionPoint((oHole.coll).getX(), (oHole.coll).getY(), _aBalls[_iLowestBall]) );
-                                            if (_oCueBall.isDragging()) {
-                                                    bSuccess = this.respotCpuCueBall(vCollPoint);
-                                            }
-                                            if( bSuccess && (!this.findCollisionForCueBall(vCollPoint)) ){
-                                                    bSuccess = false;	
-                                            }
-
-                                    }else {
-                                            bSuccess = false;
-                                    }
-                            }else {
-                                    bSuccess = false;
-                            }
-
-                            
-                            if(!bSuccess){*/
-                                    var oHole= this.setHoleToAim(_oCueBall, _aBalls[_iLowestBall], _iLowestBall,aEdges);
-                                    if (oHole !== null) {
-                                            bSuccess = true;
-                                            if (_oCueBall.isDragging()) {
-                                                    bSuccess = this.respotCpuCueBall(oHole.coll);
-                                            }
-                                            if( (bSuccess && (!this.findCollisionForCueBall(oHole.coll)) ) ){	
-                                                    bSuccess = false;
-                                            }	
-                                    }else {
-                                            bSuccess = false;
-                                    }
-                            //}
-
-                            //try to pot a ball numbered from the lowest+1 to 8 using the lowest numbered ball
-                            if (!bSuccess) {
-                                    for (var h = _iLowestBall + 1; h < BALL_NUMBER+1;h++){
-                                            var oHole = this.setHoleToAim(_aBalls[_iLowestBall],_aBalls[h], h,aEdges);
-                                            if (oHole != null) {
-                                                    var vCollPoint = new CVector2();
-                                                    vCollPoint.setV(this.findCollisionPoint((oHole.coll).getX(), (oHole.coll).getY(), _aBalls[_iLowestBall]) );
-                                                    
-                                                    if (_oCueBall.isDragging() ) {
-                                                            bSuccess = this.respotCpuCueBall(vCollPoint);
-                                                    }else {
-                                                            bSuccess = true;
-                                                    }
-                                                    if (bSuccess) {
-                                                            if (!this.findCollisionForCueBall(vCollPoint)) {
-                                                                    bSuccess = false;	
-                                                            }else {
-                                                                    bSuccess = true;
-                                                                    break;
-                                                            }
-                                                    }
-
-                                            }else {
-                                                    bSuccess = false;
-                                            }
-                                    }
-                            }				
-
-                            //try to pot using cushions
-                            if (!bSuccess) {
-                                    var aHoles = new Array();
-                                    //in this array we store the total distance the cue ball cover for each hole
-                                    var aTotalDist = new Array();
-                                    var aShots = new Array();
-                                    aHoles = this.setAllHolesToAim(_oCueBall, _aBalls[_iLowestBall], _iLowestBall,aEdges);
-                                    var vProjectDir = new CVector2();
-                                    //console.log(aHoles)
-                                    for (var t = 0; t < aHoles.length; t++) {
-                                            //init total distance for each adding distance from hole to lowest ball
-                                            aTotalDist[t] = aHoles[t].dist;
-                                            //get collision point for the current hole
-                                            var vCollision = new CVector2();
-                                            vCollision.setV(aHoles[t].coll);
-                                            
-                                            bSuccess = true;
-                                            if (_oCueBall.isDragging()) {
-                                                    bSuccess = this.respotCpuCueBall(vCollision);
-                                            }
-                                            if(bSuccess){
-                                                    //verify if we can shot using the top left cushion of table 
-                                                    vProjectDir.set(0, -1);
-
-                                                    //collect all the table edges							
-                                                    aShots[t] = this._getEdgeShot(vCollision, vProjectDir, aEdges);
-                                                    //update total distance of best shot for current hole
-                                                    if (aShots[t] === undefined) {
-                                                            aTotalDist[t] += 9000;
-                                                            bSuccess = false;
-                                                    }else{
-                                                            aTotalDist[t] += aShots[t].dist;
-                                                            bSuccess = true;
-                                                    }
-                                            }
-                                    }
-                                    //console.log("aTotalDist "+aTotalDist)
-                                    if (!bSuccess) {
-                                            //if any previous shot is unsuccesful, cpu simply shot towards lowest numbered ball direction
-                                            var vDir = new CVector2();
-                                            vDir.setV(_aBalls[_iLowestBall].getPos());
-                                            vDir.subtract(_oCueBall.getPos());
-                                            vDir.normalize();
-                                            if (_oCueBall.isDragging()) {
-                                                    _oCueBall.setPos( CUE_BALL_POS.x, CUE_BALL_POS.y );
-                                            }
-                                            this.cpuShot(vDir);
-                                    }else{
-                                            var iMinDist = aTotalDist[0];
-                                            var iSelected = 0;
-                                            for (var x = 1; x < aTotalDist.length; x++) {
-                                                    if (aTotalDist[x] < iMinDist) {
-                                                            iMinDist = aTotalDist[x];
-                                                            iSelected = x;
-                                                    }
-                                            }
-                                            this.cpuShot(aShots[iSelected].dir);
-                                    }
-
-                            }	
-                            break;
-                    }
-                    case GAME_MODE_EIGHT: {
-                            bSuccess = false;
-                            
-                            var aEdges = _oPhysicsController.getEdges();
-                         
-                            if (_aBallsToPotPlayers[s_oGame.getCurTurn()-1] === 0) {
-                                    //try to pot 8Ball
-                                    var oHole = this.setHoleToAim(_aBalls[0], _aBalls[8], 8, aEdges);
-                                    //console.log("oHole: " + oHole);
-                                    if (oHole !== null) {
-                                            bSuccess = true;
-                                            if (_aBalls[0].isDragging()) {
-                                                    bSuccess = this.respotCpuCueBall(oHole.coll,8);
-                                            }
-                                            if( (bSuccess && (!this.findCollisionForCueBall(oHole.coll, _aBalls[8], new CVector2(oHole.hole.x, oHole.hole.y))) ) ){	
-                                                    bSuccess = false;
-                                            }	
-                                    }else {
-                                            bSuccess = false;
-                                    }
-                                    if (!bSuccess) {
-                                            var aHoles = new Array();
-                                            //in this array we store the total distance the cue ball cover for each hole
-                                            var aTotalDist = new Array();
-                                            var aShots = new Array();
-                                            aHoles = this.setAllHolesToAim(_aBalls[0], _aBalls[8], 8,aEdges);
-                                            var vProjectDir = new CVector2();
-
-                                            for (var t = 0; t < aHoles.length; t++) {
-                                                    //init total distance for each adding distance from hole to current ball
-                                                    aTotalDist[t] = aHoles[t].dist;
-                                                    //get collision point for the current hole
-                                                    var vCollision = new CVector2();
-                                                    vCollision.setV(aHoles[t].coll);
-                                                    if (_oCueBall.isDragging()) {
-                                                            bSuccess = this.respotCpuCueBall(vCollision,8);
-                                                    }else {
-                                                            bSuccess = true;
-                                                    }
-                                                    if(bSuccess){
-                                                            bSuccess = this.prepareEdgeShot(t,vCollision, vProjectDir, aEdges,aTotalDist);
-                                                    }
-                                            }
-                                            if (!bSuccess) {
-                                                    //if any previous shot is unsuccesful, cpu simply shot towards a ball direction
-                                                    var oSelectedBall;
-                                                    var vDir = new CVector2();
-                                                    vDir.setV(_aBalls[8].getPos());
-                                                    vDir.subtract(_aBalls[0].getPos());
-                                                    vDir.normalize();
-                                                    if (_aBalls[0].isDragging()) {
-                                                            _aBalls[0].setPos( CUE_BALL_POS.x, CUE_BALL_POS.y );
-                                                    }
-                                                    this.cpuShot(vDir);
-                                            }
-                                    }
-                            }else {
-                                    //store all the balls a player can legally pot
-                                    var iStart = 1;
-                                    var iEnd = BALL_NUMBER + 1;
-                                    var aBalls = new Array();
-                                    if (s_oGame.isSuiteAssigned()) {
-                                            if (s_oGame.getSuiteForCurPlayer() == "solid") {
-                                                    iStart = 1;
-                                                    iEnd = 9;
-                                            }else {
-                                                    iStart = 9;
-                                                    iEnd = 16;
-                                            }	
-                                    }
-                                    for (var k = iStart; k < iEnd; k++) {
-                                            if( (k !== 8) && (_aBalls[k].isBallOnTable() ) ){
-                                                    aBalls.push(_aBalls[k]);
-                                            }
-                                    }
-                                          
-                                    for (var t = 0; t < aBalls.length; t++) {
-                                            var oHole= this.setHoleToAim(_aBalls[0], aBalls[t], aBalls[t].getNumber(),_aFieldEdges);
-           
-                                            if (oHole !== null) {
-                                                    bSuccess = true;
-                                                    
-                                                    if(DEBUG_SHOW_CPU_BALL_TRAJECTORY){
-                                                        console.log("palla : " + aBalls[t].getNumber());
-                                                        console.log(oHole);
-                                                        console.log("*********");
-
-                                                        var oPosBallToCollide = {x: oHole.coll.getX(), y: oHole.coll.getY()};
-                                                        _oContainer.addChild(createGraphicCircle(oPosBallToCollide, 6, 10000, "#fff"));
-
-                                                        _oContainer.addChild(createGraphicLine(
-                                                                                                oPosBallToCollide,
-                                                                                                oHole.hole,
-                                                                                                3,
-                                                                                                10000,
-                                                                                                "#fff"
-                                                                                            ));
-                                                    }
-                                                    
-                                                    if (_oCueBall.isDragging()) {
-                                                            bSuccess = this.respotCpuCueBall(oHole.coll,aBalls[t].getNumber());
-                                                    }
-                                                    if( (bSuccess && (!this.findCollisionForCueBall(oHole.coll, aBalls[t], new CVector2(oHole.hole.x, oHole.hole.y))) ) ){	
-                                                            bSuccess = false;
-                                                    }else {
-                                                            break;
-                                                    }
-                                            }else {
-                                                    bSuccess = false;
-                                            }
-                                    }
-                                    
-                                    if (!bSuccess) {					
-                                            for (var k = 0; k < aBalls.length; k++) {
-                                                 
-                                                    var aHoles = new Array();
-                                                    //in this array we store the total distance the cue ball cover for each hole
-                                                    var aTotalDist = new Array();   
-                                                    
-                                                    aHoles = this.setAllHolesToAim(_oCueBall, aBalls[k], k,aEdges);
-                                                    var vProjectDir = new CVector2();
-                                                    for (var t = 0; t < aHoles.length; t++) {
-                                                            //init total distance for each adding distance from hole to lowest ball
-                                                            aTotalDist[t] = aHoles[t].dist;
-                                                            //get collision point for the current hole
-                                                            var vCollision = new CVector2();
-                                                            vCollision.setV(aHoles[t].coll);
-                                                      
-                                                            if (_oCueBall.isDragging()) {
-                                                                    bSuccess = this.respotCpuCueBall(vCollision,aBalls[k].getNumber());
-                                                            }else {
-                                                                    bSuccess = true;
-                                                            }
-                                                            
-                                                            if(bSuccess){
-                                                                bSuccess = this.prepareEdgeShot(t,vCollision, vProjectDir, aEdges,aTotalDist);
-                                                            }
-                                                    }
-                                            }
-                                    }
-                                   
-                                    if (!bSuccess) {
-                                        //if any previous shot is unsuccesful, cpu simply shot towards a ball direction
-                                        var oSelectedBall;
-                                        for (var k = iStart; k < iEnd; k++) {
-                                            if( (k !== 8 || _aBallsToPotPlayers[s_oGame.getCurTurn()-1] === 0)
-                                                && (_aBalls[k].isBallOnTable() ) ){
-                                                var bCollision = false;
-                                                
-                                                var oEdgeCueToBall= new CEdge();
-                                                oEdgeCueToBall.set(_oCueBall.getX(), _oCueBall.getY(), _aBalls[k].getX(), _aBalls[k].getY());
-                                                oSelectedBall = _aBalls[k];
-                                                
-                                                for (var j = 1; j < (BALL_NUMBER+1); j++) {
-                                                    if ( (j !== k) &&( collideEdgeWithCircle(oEdgeCueToBall,_aBalls[j].getPos(),BALL_DIAMETER) )  ) {
-                                                        bCollision = true;
-                                                        break;
-                                                    }
-                                                }
-                                                if(!bCollision){
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                        var vDir = new CVector2();
-                                        vDir.setV(oSelectedBall.getPos());
-                                        vDir.subtract(_oCueBall.getPos());
-                                        vDir.normalize();
-
-                                        if (_oCueBall.isDragging()) {
-                                                _oCueBall.setPos( CUE_BALL_POS.x, CUE_BALL_POS.y );
-                                        }
-                                        this.cpuShot(vDir);
-                                    }
-                            }
-                            break;
-                    }
-            }            
-    };
-    
-    //this function respot ball for CPU if previous player commited a fault
-    this.respotCpuCueBall = function(vCollPoint,iBallToHit) {
-            var iBallIndex;
-            switch(s_iGameMode) {
-                    case GAME_MODE_NINE: {
-                            iBallIndex = _iLowestBall;
-                            break;
-                    }
-                    case GAME_MODE_EIGHT: {
-                            iBallIndex = iBallToHit;
-                            break;
-                    }
-            }
-            var vCueBallPos = new CVector2();
-            vCueBallPos.setV(_aBalls[iBallIndex].getPos());
-            vCueBallPos.subtract(vCollPoint);
-            vCueBallPos.normalize();
-            vCueBallPos.invert();
-            vCueBallPos.scalarProduct(BALL_DIAMETER * 2);
-            vCueBallPos.add(vCollPoint);
-         
-            for (var k = iBallIndex+1; k < _aBalls.length;k++){
-                    var tmpDist = distance2( vCueBallPos, _aBalls[k].getPos() );
-                    if ( tmpDist <= BALL_DIAMETER_QUADRO) {
-                            return false;
-                    }
-            }
-            
-            if ( (vCueBallPos.getX() > CUE_BALL_RESPOT_1.x) &&
-                     (vCueBallPos.getX() < CUE_BALL_RESPOT_3.x) &&
-                     (vCueBallPos.getY() > CUE_BALL_RESPOT_1.y) &&
-                     (vCueBallPos.getY() < CUE_BALL_RESPOT_3.y) ){
-
-                    _oCueBall.setPos(vCueBallPos.getX(), vCueBallPos.getY());
-                    _oCueBall.setDragging(false);
-                    return true;	 
-            }else {
-                    console.trace("no respotCpuCueBall "+vCueBallPos.getX()+","+vCueBallPos.getY());
-                    return false;
-            }
-    };
-    
-    //find the collision point for a cpu shot
-    this.findCollisionPoint = function(oXFirst,oYFirst,oSecond) {
-                
-        var vDirToHole = new CVector2();
-        vDirToHole.set(oXFirst,oYFirst);  
-
-        vDirToHole.subtract(oSecond.getPos());
-
-        vDirToHole.normalize();
-              
-        vDirToHole.invert();
-        var vCollisionPoint = new CVector2();
-
-        var fErrorRatio = randomFloatBetween(
-                                                _oCpuDifficultyParams[_iCpuShotTurn].min,
-                                                _oCpuDifficultyParams[_iCpuShotTurn].max
-                                            );
-                                    
-        vDirToHole.scalarProduct(BALL_DIAMETER * fErrorRatio);
-
-        vDirToHole.add(oSecond.getPos());
-
-        vCollisionPoint.setV(vDirToHole);
-
-        return vCollisionPoint;
-    };
-    
-    //manage stick animation for a cpu shot
-    this.cpuShot = function(vCueBallDir, fDistance = MAX_FORCE_PER_DISTANCE) {
-        //console.trace("cpuShot");
-     
-        
-        fDistance = fDistance > MAX_FORCE_PER_DISTANCE ? MAX_FORCE_PER_DISTANCE : fDistance;
-        _iPowerShot = linearFunction(
-                                        fDistance,
-                                        0, MAX_FORCE_PER_DISTANCE,
-                                        3, MAX_POWER_SHOT
-                                    );
-        //_iPowerShot = MAX_POWER_SHOT;
-      //  console.log(_iPowerShot);
-        _vStickDirection.setV(vCueBallDir);
-
-        _iMaxTimeAnimationStick = _iPowerShot>100 ? TIME_ANIMATION_SHOT_ELASTIC :TIME_ANIMATION_SHOT_BACK;
-
-        _oStick.setPos(_aBalls[0].getX(),_aBalls[0].getY());
-
-        _bHoldStick = true;
-        var vStickInverse = new CVector2();
-        vStickInverse.setV(_vStickDirection);
-        vStickInverse.invert();
-        vStickInverse.normalize();
-        vStickInverse.scalarProduct(Math.floor(_iPowerShot / 10) );
-        var vStickPos = new CVector2();
-        vStickPos.set(_oStick.getX(), _oStick.getY());
-        vStickInverse.add(vStickPos);
-        var iAngle = toDegree( angleBetweenVectors( _vStickInitDir,_vStickDirection ) );
-
-        if ( vCueBallDir.getY() >0 ){
-                iAngle = (180-iAngle)+180;
-        }
-        _oStick.setRotation(iAngle+180);
-        _oStick.setVisible(true);
-        _oStick.setPos(vStickInverse.getX(),vStickInverse.getY());
-
-        _bHoldStick = false;
-        _bReadyForShot = true;
-        _iState = STATE_TABLE_SHOOT;
-           
-    };
-    
-    //find collision point between lowest ball and cue ball	
-    this.findCollisionForCueBall = function(vCollPoint, oBallToPot, oHolePoint) {
-            if (!this._checkCpuBallCollision(vCollPoint,_oCueBall.getPos(),0,0,new Array())) {
-//                    console.log("BallToHole: " + distance(oBallToPot, oHolePoint));
-//                    console.log("CueToBall: " +  distance(oBallToPot, _oCueBall.getPos()));
-                    
-                    var fDistance = distance(oBallToPot, oHolePoint) + distance(oBallToPot, _oCueBall.getPos());
-                    
-                    var vCueBallDir = new CVector2();
-                    vCueBallDir.setV(vCollPoint);
-                    vCueBallDir.subtract(_oCueBall.getPos());
-
-                    vCueBallDir.scalarProduct(0.3);
-                    
-                    vCueBallDir.normalize();
-                    this.cpuShot(vCueBallDir, fDistance);
-                    
-                    return true;
-            }else {
-                    return false;
-            }
-
-    };
-    
-    //get all the possible holes in which you can pot lowest ball
-    this.setAllHolesToAim = function(oBall, oBallToHit, iNumber,aEdges) {
-            var aProbableHole = new Array();
-
-            //find the hole we want to aim
-            for (var i = 0; i < HOLE_CPU_POINTS.length; i++) {
-                var oEdgeWithHole = new CEdge();
-                //console.log("HOLE "+i)
-                oEdgeWithHole.set(oBallToHit.getX(), oBallToHit.getY(), HOLE_CPU_POINTS[i].x, HOLE_CPU_POINTS[i].y);
-                var iDist = distance(oEdgeWithHole.getPointA(), oEdgeWithHole.getPointB());					
-
-                var bCollision = false;
-                //verify if there are other balls between ball to pot and the current hole
-                for (var j = 0; j < (BALL_NUMBER+1); j++) {
-                        if ( (j != iNumber) &&( collideEdgeWithCircle(oEdgeWithHole,_aBalls[j].getPos(),BALL_DIAMETER) )  ) {
-                                bCollision = true;
-                                //console.log("collision with "+j)
-                                break;
-                        }
-                }	
-                //verify if current ball path is far from cushions
-                for (var k = 0; k < aEdges.length; k++) {
-                        if (collideEdgeWithEdge(oEdgeWithHole, aEdges[k])) {
-                                bCollision = true;
-                                //console.log("hit edge "+k)
-                                break;
-                        }
-                }
-
-                if (!bCollision) {
-
-                        //we find the dir to the hole 
-                        aProbableHole.push( { //hole:this["oHole" + i],
-                                                                  coll:this.findCollisionPoint(HOLE_CPU_POINTS[i].x, HOLE_CPU_POINTS[i].y, oBallToHit),
-                                                                  dist:iDist});
-                        //console.log("add aProbableHole");
-                }
-            }
-
-            if (aProbableHole.length !== 0) {
-                var iLen = aProbableHole.length;
-                var iInd = 0;
-                while(iLen>0) {
-                    var vCollPoint = aProbableHole[iInd].coll;
-                    var bSuccess = true;
-                    if ( (oBall.getNumber() === 0) && (oBall.isDragging()) ) {
-                            bSuccess=this.respotCpuCueBall(vCollPoint,oBallToHit.getNumber());
-                    }
-                    if( (!bSuccess) || (this._checkCpuBallCollision(vCollPoint,oBall.getPos(),oBall.getNumber(),iNumber, new Array())) ){
-                            aProbableHole.splice(iInd, 1);
-                    }else {
-                            iInd++;
-                    }
-                    iLen--;
-                }
-            }else {
-                    return [];
-            }
-            return aProbableHole;
-
-    };
-        
-    //first parameter: first ball
-    //second parameter: ball to hit
-    //third parameter: number of ball to hit
-    //array with all table edges
-    this.setHoleToAim = function(oBall,oBallToHit,iNumber,aEdges) {
-            var aProbableHole = new Array();
-
-            var iCollisionRadiusDetect = BALL_RADIUS*1.1;
-            //find the hole we want to aim
-            for (var i = 0; i < 6; i++) {
-                   
-                    var oEdgeWithHole = new CEdge();
-                    oEdgeWithHole.set(oBallToHit.getX(), oBallToHit.getY(), HOLE_CPU_POINTS[i].x, HOLE_CPU_POINTS[i].y);
-                    var iDist = distance2(oEdgeWithHole.getPointA(), oEdgeWithHole.getPointB());					
-                    
-                    var bCollision = false;
-                    //verify if there are other balls between ball to pot and the current hole
-                    for (var j = 0; j < (BALL_NUMBER+1); j++) {
-                            if ( (j != iNumber) &&( collideEdgeWithCircle(oEdgeWithHole,_aBalls[j].getPos(),BALL_DIAMETER) )  ) {
-                                    bCollision = true;
-                          
-                                    break;
-                            }
-                    }	
-                    for (var k = 0; k < aEdges.length; k++) {
-                            if (collideEdgeWithEdge(oEdgeWithHole, aEdges[k])) {
-                                    bCollision = true;
-                               
-                                    break;
-                            }
-                    }
-                    
-                    var aPoints = lineInterpolate(oEdgeWithHole, iCollisionRadiusDetect, 3);
-                    var aEdges = _oPhysicsController.getEdgesByHoleID(i);
-//                    var vHolePoint = new CVector2(HOLE_CPU_POINTS[i].x, HOLE_CPU_POINTS[i].y);
-//                    aPoints.push(vHolePoint);
-                    
-                    for(var n = 0; n < aPoints.length; n++){
-                        if(bCollision){
-                            break;
-                        }
-                        for(var m = 0; m < aEdges.length; m++){
-                            bCollision = collideEdgeWithCircle(aEdges[m], aPoints[n], iCollisionRadiusDetect);
-                            if(bCollision){
-                                if(DEBUG_SHOW_PREDICT_TRAJECTORY_COLLISION){
-                                    _oContainer.addChild(
-                                                            createGraphicLine(
-                                                                    {x:oBallToHit.getX(), y:oBallToHit.getY() },
-                                                                    HOLE_CPU_POINTS[i],
-                                                                    3,
-                                                                    6000,
-                                                                    "#f0f"
-                                                            ));
-                                    _oContainer.addChild(createGraphicCircle(
-                                                                                {x:aPoints[n].getX(), y: aPoints[n].getY()},
-                                                                                iCollisionRadiusDetect,
-                                                                                6000,
-                                                                                "#0ff"
-                                                                             ));  
-                                }
-                                break;
-                            }                                 
-                        }
-                    }
-                    
-                    if (!bCollision) {
-                        //we find the dir to the hole
-                        var oBallCollPoint = this.findCollisionPoint(HOLE_CPU_POINTS[i].x, HOLE_CPU_POINTS[i].y, oBallToHit);
-
-                        //DETECT IF CUE BALL COLLIDE WITH CUSHION BACKWARD SELECTED BALL
-                        var aEdge = _oPhysicsController.getEdgesByHoleID(i);
-                        var bCueWillCollideCuschion = false;
-                        for(var j = 0; j< aEdge.length; j++){
-                            if(collideEdgeWithCircle(aEdges[j], oBallCollPoint, BALL_RADIUS)){
-                                bCueWillCollideCuschion = true;
-                                break;
-                            }
-                         }   
-                         
-                        if(!bCueWillCollideCuschion){
-                            aProbableHole.push({ 
-                                                   hole:HOLE_CPU_POINTS[i],
-                                                   coll:oBallCollPoint,
-                                                   dist:iDist 
-                                               });
-                        }else{
-                            if(DEBUG_SHOW_PREDICT_TRAJECTORY_COLLISION){
-                                _oContainer.addChild(createGraphicCircle(
-                                                                            {x: oBallCollPoint.getX(), y: oBallCollPoint.getY()},
-                                                                            iCollisionRadiusDetect,
-                                                                            6000,
-                                                                            "#0f0"
-                                                                         ));  
-                            }
-                        }
-                    }
-            }
-
-            if (aProbableHole.length !== 0) {
-                    //console.log(JSON.stringify(aProbableHole));
-                    sortByKey(aProbableHole, "dist");
-                    //console.log(JSON.stringify(aProbableHole));
-                
-                    var iLen = aProbableHole.length;
-                    var iInd = 0;
-                    while(iLen>0) {
-                            var vCollPoint = aProbableHole[iInd].coll;
-                            var bSuccess = true;
-                            if ( oBall.getNumber() === 0 && oBall.isDragging() ) {
-                                    bSuccess = this.respotCpuCueBall(vCollPoint,oBallToHit.getNumber());
-                            }
-                            if( (!bSuccess) || (this._checkCpuBallCollision(vCollPoint,oBall.getPos(),oBall.getNumber(),oBall.getNumber(), new Array())) ){
-                                    aProbableHole.splice(iInd, 1);
-                            }else {
-                                    iInd++;
-                            }
-                            iLen--;
-                    }
-                    if (aProbableHole.length == 0) {
-                            //set a shot to cushions
-                            return null;
-                    }else {
-//                            var iMinDist = aProbableHole[0].dist;
-                            var oHoleChoosen = aProbableHole[0];
-//                            for (var k = 1; k < aProbableHole.length; k++) {
-//                                    if (iMinDist > aProbableHole[k].dist) {
-//                                            iMinDist = aProbableHole[k].dist;
-//                                            oHoleChoosen = aProbableHole[k];
-//                                    }
-//                            }
-                            return oHoleChoosen;
-                    }
-
-            }else {
-                    return null;
-            }
-
-    };
-    
-    //cpu tries an edge shot
-    //first: point where cue ball collide lowest ball
-    //second:projection of collision point towards the cushion
-    //third:all the edges to consider
-    this._getEdgeShot = function(vCollision,vDir,aEdges) {
-            var oCushionToConsider;
-            var vCollPoint = new CVector2();
-            vCollPoint.setV(vCollision);
-
-            var iAngle = 1;
-            var oEdgeCollPoint = new CEdge();
-
-            vDir.scalarProduct(600);
-            var aPossibleShots = new Array();
-
-            while (iAngle < 360) {
-                //console.log("#######ANGLE "+iAngle)
-                    rotateVector2D(toRadian(1), vDir);
-                    var vProjectedPoint = new CVector2();
-                    vProjectedPoint.set(vCollPoint.getX() + vDir.getX(), vCollPoint.getY() + vDir.getY());
-                    oEdgeCollPoint.set(vCollision.getX(), vCollision.getY(), vProjectedPoint.getX(), vProjectedPoint.getY());
-                    var vPointOnCushion = new CVector2();
-
-                    for (var k = 0; k < aEdges.length; k++) {
-                            if (collideEdgeWithEdge(oEdgeCollPoint, aEdges[k], vPointOnCushion)) {
-                                    oCushionToConsider = aEdges[k];
-                                    var vDirReflected = new CVector2();
-                                    vDirReflected.setV(reflectVectorV2(vDir, oCushionToConsider.getNormal()) );
-                                    var oEdgeReflectVec = new CEdge();
-                                    var vReflectedPoint = new CVector2();
-                                    vReflectedPoint.setV(vDirReflected);
-                                    vReflectedPoint.add(vPointOnCushion);
-                                    oEdgeReflectVec.set(vPointOnCushion.getX(), vPointOnCushion.getY(), vReflectedPoint.getX(), vReflectedPoint.getY());
-                                    var iDist2 = distance(vPointOnCushion, vCollision);
-                                    //console.log("oEdgeReflectVec "+oEdgeReflectVec.getPointA().toString()+","+oEdgeReflectVec.getPointB().toString())
-                                    if ( (iDist2 > BALL_DIAMETER ) && (collideEdgeWithCircle(oEdgeReflectVec, _oCueBall.getPos(), BALL_RADIUS)) ){
-                                            var bCollision = false;
-
-                                            if (this._checkCpuBallCollision(vPointOnCushion, _oCueBall.getPos(), 0, 0, new Array()) ) {
-                                                    bCollision = true;
-                                                    //console.log(k+ " 1 collision "+vPointOnCushion.getX()+","+vPointOnCushion.getY()+" and cue ball")
-                                            }else if (this._checkCpuBallCollision(vCollision, vPointOnCushion, 0, 0, new Array()) ) {
-                                                    bCollision = true;
-                                                    //console.log(k+ " 2 collision "+vCollision.getX()+","+vCollision.getY()+" and "+vPointOnCushion.getX()+","+vPointOnCushion.getY())
-                                            }
-
-                                            
-                                            if (!bCollision){
-                                                    vDirReflected.invert();
-                                                    vDirReflected.normalize();
- 
-
-                                                    var vMemorizeDir = new CVector2();
-                                                    vMemorizeDir.setV(vDirReflected);
-                                                    var iDist = distance(oEdgeReflectVec.getPointA(), oEdgeReflectVec.getPointB());
-                                                    aPossibleShots.push( { dir:vMemorizeDir, 
-                                                                           edge:oEdgeReflectVec,
-                                                                           dist: (iDist+iDist2)} );
-                                            }
-                                    }
-                            }
-                    }
-
-                    iAngle += 1;
-                    
-            }
-            
-            if(aPossibleShots.length === 0){
-                return undefined;
-            }
-            
-            var vTmpPoint= closestPointOnLine( (aPossibleShots[0].edge).getPointA(),(aPossibleShots[0].edge).getPointB(),_oCueBall.getPos());
-            var iMinDist = distance(vTmpPoint, _oCueBall.getPos());
-            var iSelectedShot = 0;
-
-            for (var t = 1; t < aPossibleShots.length; t++) {
-
-                    var vTmpPoint=closestPointOnLine( (aPossibleShots[t].edge).getPointA(),(aPossibleShots[t].edge).getPointB(),_oCueBall.getPos());
-                    var iDist = distance(vTmpPoint, _oCueBall.getPos());
-
-                    if (iMinDist > iDist) {
-                            iMinDist = iDist;
-                            iSelectedShot = t;
-                    }			
-            }
-            return aPossibleShots[iSelectedShot];
-
-    };
-    
-    this.prepareEdgeShot = function(t,vCollision, vProjectDir, aEdges,aTotalDist) {
-            var aShots = new Array();
-            //verify if we can shot using the top left cushion of table 
-            vProjectDir.set(0, -1);
-            var bSuccess = false;
-            //collect all the table edges							
-            aShots[t] = this._getEdgeShot(vCollision, vProjectDir, aEdges);
-            //update total distance of best shot for current hole
-            if (aShots[t] == undefined) {
-                    aTotalDist[t] += 9000;
-                    bSuccess = false;
-            }else{
-                    aTotalDist[t] += aShots[t].dist;
-                    bSuccess = true;
-            }
-            //verify if we can shot using the right cushion of table 
-            if(!bSuccess){
-                    //verify if we can shot using the top left cushion of table 
-                    vProjectDir.set(1, 0);
-
-                    //collect all the table edges							
-                    aShots[t] = this._getEdgeShot(vCollision, vProjectDir, aEdges);
-                    //update total distance of best shot for current hole
-                    if (aShots[t] === undefined) {
-                            aTotalDist[t] += 9000;
-                            bSuccess = false;
-                    }else{
-                            aTotalDist[t] += aShots[t].dist;
-                            bSuccess = true;
-                    }
-                    if(!bSuccess){
-                            //verify if we can shot using the bottom cushion of table 
-                            vProjectDir.set(0, 1);
-
-                            //collect all the table edges							
-                            aShots[t] = this._getEdgeShot(vCollision, vProjectDir, aEdges);
-                            //update total distance of best shot for current hole
-                            if (aShots[t] == undefined) {
-                                    aTotalDist[t] += 9000;
-                                    bSuccess = false;
-                            }else{
-                                    aTotalDist[t] += aShots[t].dist;
-                                    bSuccess = true;
-                            }
-                            if(!bSuccess){
-                                    //verify if we can shot using the left cushion of table 
-                                    vProjectDir.set(-1, 0);
-
-                                    //collect all the table edges							
-                                    aShots[t] = this._getEdgeShot(vCollision, vProjectDir, aEdges);
-                                    //update total distance of best shot for current hole
-                                    if (aShots[t] == undefined) {
-                                            aTotalDist[t] += 9000;
-                                            return false;
-                                    }else{
-                                            aTotalDist[t] += aShots[t].dist;
-                                            return true;
-                                    }	
-                            }else {
-                                    this._edgeShot(aTotalDist,aShots);
-                            }
-                    }else {
-                            this._edgeShot(aTotalDist,aShots);
-                    }
-            }else {
-                    this._edgeShot(aTotalDist,aShots);
-            }
-    };
-    
-    this._edgeShot = function (aTotalDist,aShots) {
-        if(aShots === undefined){
-            return;
-        }
-        var iMinDist = aTotalDist[0];
-        var iSelected = 0;
-        for (var x = 1; x < aTotalDist.length; x++) {
-                if (aTotalDist[x] < iMinDist) {
-                    iMinDist = aTotalDist[x];
-                    iSelected = x;
-                }
-        }
-        
-        var oDirShot = aShots[iSelected];
-
-        oDirShot = oDirShot === undefined ? undefined : oDirShot.dir;
-        
-        this.cpuShot(oDirShot);
-    };
-    
     //set the lowest numbered ball on table each turn
     this.setLowestBall = function() {
         for ( var i = 1; i < _aBalls.length; i++) {
@@ -2479,28 +1621,18 @@ function CTable(oParentContainer, oCpuDifficultyParams){
     this.update = function(){
         this.updatePhysics();
         this.renderBalls();
-        var bIsCpuTurn = this.isCpuTurn();
-
         switch(_iState){
             case STATE_TABLE_PLACE_CUE_BALL:
             case STATE_TABLE_PLACE_CUE_BALL_BREAKSHOT:
             case STATE_TABLE_MOVE_STICK:{
-                    if(bIsCpuTurn){
-                        return;
-                    }
                     this.updateStick();
                     this.renderStickDirection();
-
                     break;
             }
             case STATE_TABLE_SHOOT:{
-                    if ( (s_iPlayerMode === GAME_MODE_CPU) && (s_oGame.getCurTurn() === 2) && _bReadyForShot) {
-                        this.renderStickDirection();
-                    }
                     break;
             }
             case STATE_TABLE_SHOOTING:{
-                    
                     break;
             }
         }
@@ -2514,7 +1646,7 @@ function CTable(oParentContainer, oCpuDifficultyParams){
     
     s_oTable = this;
     
-    this._init(oCpuDifficultyParams);
+    this._init();
 }
 
 var s_oTable = null;


### PR DESCRIPTION
## Summary
- drop CPU turn flag from CBall rendering
- strip AI shot routines and CPU-specific checks from table
- simplify table update loop for human-only gameplay

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890184d54b48327b45f8bae637e8d00