### PR TITLE
Clarify player modes and stub score updates

### DIFF
--- a/js/CGame.js
+++ b/js/CGame.js
@@ -357,6 +357,10 @@ function CGame(){
         _oGameState.resetWinStreak();
         //oWinStreak.text = "Win Streak: "+_oGameState.toJSON().winStreak;
     };
+
+    this.updateScore = function(iVal){
+        _oGameState.updateScore(iVal);
+    };
       
     this.gameOver = function(szText){
         _oGameOverPanel.show(szText);

--- a/js/CInterface.js
+++ b/js/CInterface.js
@@ -101,6 +101,8 @@ function CInterface(oParentContainer){
     this.resetSpin = function(){
         _oBallSpinGUI.resetSpin();
     };
+
+    this.updateScore = function(iScore){};
     
     this.getSideSpin = function(){
         return _oBallSpinGUI.getSideSpin();

--- a/js/CMain.js
+++ b/js/CMain.js
@@ -365,6 +365,6 @@ var s_bStorageAvailable = true;
 var s_bInteractiveHelp = true;
 var s_aSoundsInfo;
 var s_iGameMode = GAME_MODE_EIGHT;
-var s_iPlayerMode = GAME_MODE_TWO;
+var s_iPlayerMode = PLAYER_MODE_TWO;
 var s_iCurLang = LANG_EN;
 var s_iGameDifficulty = EASY;

--- a/js/CMenu.js
+++ b/js/CMenu.js
@@ -7,6 +7,7 @@ function CMenu(){
 
     var _oBg;
     var _oButPlayTwo;
+    var _oButPlayTournament;
     var _oAudioToggle;
     var _oButCredits;
     var _oFade;
@@ -23,6 +24,10 @@ function CMenu(){
         _pStartPosButTwo = {x: CANVAS_WIDTH/2 - 250, y: CANVAS_HEIGHT - 220};
         _oButPlayTwo = new CGfxButton(_pStartPosButTwo.x, _pStartPosButTwo.y, s_oSpriteLibrary.getSprite('vs_man_panel'), s_oStage);
         _oButPlayTwo.addEventListener(ON_MOUSE_UP, this._onButPlayTwo, this);
+
+        _pStartPosButTournament = {x: CANVAS_WIDTH/2 + 250, y: CANVAS_HEIGHT - 220};
+        _oButPlayTournament = new CGfxButton(_pStartPosButTournament.x, _pStartPosButTournament.y, s_oSpriteLibrary.getSprite('vs_pc_panel'), s_oStage);
+        _oButPlayTournament.addEventListener(ON_MOUSE_UP, this._onButPlayTournament, this);
 
         // Audio toggle
         if(DISABLE_SOUND_MOBILE === false || s_bMobile === false){
@@ -85,6 +90,7 @@ function CMenu(){
     this.unload = function(){
         _oButCredits.unload();
         _oButPlayTwo.unload();
+        _oButPlayTournament.unload();
 
         if(DISABLE_SOUND_MOBILE === false || s_bMobile === false){
             _oAudioToggle.unload();
@@ -109,10 +115,11 @@ function CMenu(){
         }
         _oButCredits.setPosition(_pStartPosCredits.x + s_iOffsetX, _pStartPosCredits.y + s_iOffsetY);
         _oButPlayTwo.setPosition(_pStartPosButTwo.x, _pStartPosButTwo.y - s_iOffsetY);
+        _oButPlayTournament.setPosition(_pStartPosButTournament.x, _pStartPosButTournament.y - s_iOffsetY);
     };
 
     this._onButPlayTwo = function(){
-        s_iPlayerMode = GAME_MODE_TWO;
+        s_iPlayerMode = PLAYER_MODE_TWO;
         s_iGameMode = GAME_MODE_EIGHT;
         this._onExit(function(){
             s_oMenu.unload();
@@ -123,6 +130,11 @@ function CMenu(){
 
     this._onButCreditsRelease = function(){
         new CCreditsPanel();
+    };
+
+    this._onButPlayTournament = function(){
+        s_iPlayerMode = PLAYER_MODE_TOURNAMENT;
+        console.log("Tournament mode is not implemented yet");
     };
 
     this._onAudioToggle = function(){

--- a/js/settings.js
+++ b/js/settings.js
@@ -35,9 +35,9 @@ var GAME_MODE_EIGHT = 0;
 var GAME_MODE_NINE = 1;
 var GAME_MODE_TIME = 2;
 
-var GAME_MODE_CPU = 0;
-var GAME_MODE_TWO = 1;
-var GAME_MODE_TOURNAMENT = 2; // Placeholder for future tournament logic
+var PLAYER_MODE_CPU = 0;
+var PLAYER_MODE_TWO = 1;
+var PLAYER_MODE_TOURNAMENT = 2; // Placeholder for future tournament logic
 
 var STATE_TABLE_PLACE_CUE_BALL_BREAKSHOT  = 0;
 var STATE_TABLE_PLACE_CUE_BALL = 1;


### PR DESCRIPTION
## Summary
- Rename `GAME_MODE_*` player flags to clearer `PLAYER_MODE_*` constants
- Expose a placeholder Tournament option in the main menu
- Stub score update logic to avoid runtime errors when scoring is unused

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689026258be88327af580f30abb09416