### PR TITLE
Remove unused CPU player mode

### DIFF
--- a/js/CMain.js
+++ b/js/CMain.js
@@ -365,6 +365,6 @@ var s_bStorageAvailable = true;
 var s_bInteractiveHelp = true;
 var s_aSoundsInfo;
 var s_iGameMode = GAME_MODE_EIGHT;
-var s_iPlayerMode = PLAYER_MODE_TWO;
+var s_iPlayerMode = PLAYER_MODE_TWO; // default to two-player mode
 var s_iCurLang = LANG_EN;
 var s_iGameDifficulty = EASY;

--- a/js/settings.js
+++ b/js/settings.js
@@ -35,9 +35,8 @@ var GAME_MODE_EIGHT = 0;
 var GAME_MODE_NINE = 1;
 var GAME_MODE_TIME = 2;
 
-var PLAYER_MODE_CPU = 0;
-var PLAYER_MODE_TWO = 1;
-var PLAYER_MODE_TOURNAMENT = 2; // Placeholder for future tournament logic
+var PLAYER_MODE_TWO = 0;
+var PLAYER_MODE_TOURNAMENT = 1; // Placeholder for future tournament logic
 
 var STATE_TABLE_PLACE_CUE_BALL_BREAKSHOT  = 0;
 var STATE_TABLE_PLACE_CUE_BALL = 1;


### PR DESCRIPTION
## Summary
- drop unused CPU player mode constant and renumber remaining player modes
- default CMain to two-player mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890337cfa008327a46447b68b785c21