### PR TITLE
Remove CPU player mode remnants

### DIFF
--- a/js/CTable.js
+++ b/js/CTable.js
@@ -1210,7 +1210,7 @@ function CTable(oParentContainer){
                                     if (_bFirstShot) {
                                             _oCueBall.setPos(CUE_BALL_POS.x, CUE_BALL_POS.y);
                                             s_oGame.changeTurn();
-                                            this.targetting(true);
+                                            _oStick.setVisible(true);
                                     }else {
                                             //if player pot 9ball, we re-spot the 9 ball
                                             if (_aBalls[9].isBallOnTable() == false) {
@@ -1416,11 +1416,6 @@ function CTable(oParentContainer){
              
             _iShotPoints = 0;
             return bEndGame;
-    };
-    
-    this.targetting = function(bValue) {
-            //m_bTargetting = bValue;
-            _oStick.setVisible(bValue);
     };
     
     this._assignSuit = function(){

--- a/js/settings.js
+++ b/js/settings.js
@@ -35,9 +35,8 @@ var GAME_MODE_EIGHT = 0;
 var GAME_MODE_NINE = 1;
 var GAME_MODE_TIME = 2;
 
-var PLAYER_MODE_CPU = 0;
-var PLAYER_MODE_TWO = 1;
-var PLAYER_MODE_TOURNAMENT = 2; // Placeholder for future tournament logic
+var PLAYER_MODE_TWO = 0;
+var PLAYER_MODE_TOURNAMENT = 1; // Placeholder for future tournament logic
 
 var STATE_TABLE_PLACE_CUE_BALL_BREAKSHOT  = 0;
 var STATE_TABLE_PLACE_CUE_BALL = 1;


### PR DESCRIPTION
## Summary
- drop CPU player mode constant and renumber player mode values
- remove unused stick targeting wrapper in table logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890338423108327a4b2840b02b980d2