### PR TITLE
Enable audio by default and sync audio toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,13 +67,19 @@
           <script>
             $(document).ready(function(){
                      var oMain = new CMain({
-                                                audio_enable_on_startup:false, //ENABLE/DISABLE AUDIO WHEN GAME STARTS 
+                                                audio_enable_on_startup:true, //ENABLE/DISABLE AUDIO WHEN GAME STARTS
                                                 fullscreen:true,   //SET THIS TO FALSE IF YOU DON'T WANT TO SHOW FULLSCREEN BUTTON
                                                 check_orientation:true, //SET TO FALSE IF YOU DON'T WANT TO SHOW ORIENTATION ALERT ON MOBILE DEVICES
                                                 points_for_ball_pot: 20, //SET THIS VALUE TO ADD SCORE ON EVERY BALL POT BY USER
                                                 points_for_fault: -40 // SET THIS VALUE TO DECREASE SCORE ON USER FAUL
                                         });
-                     
+
+                     $(window).one("click touchstart", function(){
+                        if(s_bAudioActive){
+                            Howler.mute(false);
+                        }
+                     });
+
                      $(oMain).on("start_session", function(evt) {
                             if(getParamValue('ctl-arcade') === "true"){
                                 parent.__ctlArcadeStartSession();

--- a/js/CDifficultyMenu.js
+++ b/js/CDifficultyMenu.js
@@ -144,9 +144,9 @@ function CDifficutlyMenu() {
         }
     };
 
-    this._onAudioToggle = function () {
-        Howler.mute(s_bAudioActive);
-        s_bAudioActive = !s_bAudioActive;
+    this._onAudioToggle = function (bActive) {
+        s_bAudioActive = bActive;
+        Howler.mute(!s_bAudioActive);
     };
 
     this.resetFullscreenBut = function () {

--- a/js/CInterface.js
+++ b/js/CInterface.js
@@ -120,9 +120,9 @@ function CInterface(oParentContainer){
        s_oGame.onExit();
     };
 
-    this._onAudioToggle = function(){
-        Howler.mute(s_bAudioActive);
-	s_bAudioActive = !s_bAudioActive;
+    this._onAudioToggle = function(bActive){
+        s_bAudioActive = bActive;
+        Howler.mute(!s_bAudioActive);
     };
     
     this.resetFullscreenBut = function(){

--- a/js/CMenu.js
+++ b/js/CMenu.js
@@ -137,9 +137,9 @@ function CMenu(){
         console.log("Tournament mode is not implemented yet");
     };
 
-    this._onAudioToggle = function(){
-        Howler.mute(s_bAudioActive);
-        s_bAudioActive = !s_bAudioActive;
+    this._onAudioToggle = function(bActive){
+        s_bAudioActive = bActive;
+        Howler.mute(!s_bAudioActive);
     };
 
     this.resetFullscreenBut = function(){


### PR DESCRIPTION
## Summary
- Enable audio at startup and unmute Howler on first user interaction
- Sync audio toggle state with Howler across menus and interfaces

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68903385ab4c83278b0285103990df68