### PR TITLE
feat: improve layout and collisions

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -4,8 +4,17 @@ root {
 
 body{
     background-color: #000;
-    background-repeat: repeat-x;
-    background-position: top;   
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+}
+
+body.menu{
+    background-image: url('../sprites/bg_menu.jpg');
+}
+
+body.game{
+    background-image: url('../sprites/bg_game.jpg');
 }
 
 *, *:before, *:after {

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         
         
     </head>
-    <body ondragstart="return false;" ondrop="return false;" >
+    <body class="menu" ondragstart="return false;" ondrop="return false;" >
 	<div style="position: fixed; background-color: transparent; top: 0px; left: 0px; width: 100%; height: 100%"></div>
           <script>
             $(document).ready(function(){

--- a/js/CMain.js
+++ b/js/CMain.js
@@ -225,16 +225,20 @@ function CMain(oData){
     };
     
     
-    this.gotoMenu = function(){
-        _oMenu = new CMenu();
-        _iState = STATE_MENU;
-    };
+      this.gotoMenu = function(){
+          document.body.classList.remove('game');
+          document.body.classList.add('menu');
+          _oMenu = new CMenu();
+          _iState = STATE_MENU;
+      };
     
-    this.gotoGame = function(){
-        _oGame = new CGame();   
-							
-        _iState = STATE_GAME;
-    };
+      this.gotoGame = function(){
+          document.body.classList.remove('menu');
+          document.body.classList.add('game');
+          _oGame = new CGame();
+
+          _iState = STATE_GAME;
+      };
     
     this.levelSelected = function(iLevel){
         s_iLevelSelected = iLevel;

--- a/js/CMenu.js
+++ b/js/CMenu.js
@@ -2,10 +2,9 @@ function CMenu(){
     var _pStartPosAudio;
     var _pStartPosCredits;
     var _pStartPosFullscreen;
-    var _pStartPosButPractice;
-    var _pStartPosButOffline;
-    var _pStartPosButOnline;
-    var _pStartPosButTournament;
+    var _aCardStartPos;
+    var _cardW = 400;
+    var _cardH = 180;
 
     var _oBg;
     var _oButPractice;
@@ -24,25 +23,23 @@ function CMenu(){
         _oBg = createBitmap(s_oSpriteLibrary.getSprite('bg_menu'));
         s_oStage.addChild(_oBg);
 
-        // Mode buttons
-        var oSpriteBtn = s_oSpriteLibrary.getSprite('but_text');
-        var iStartY = CANVAS_HEIGHT/2 - 150;
+        // Card layout buttons
+        var spacingX = 50;
+        var spacingY = 40;
+        var startX = CANVAS_WIDTH / 2 - _cardW - spacingX / 2;
+        var startY = CANVAS_HEIGHT / 2 - _cardH - spacingY / 2;
 
-        _pStartPosButPractice = {x: CANVAS_WIDTH/2, y: iStartY};
-        _oButPractice = new CTextButton(_pStartPosButPractice.x, _pStartPosButPractice.y, oSpriteBtn, "SOLO PRACTICE", FONT_GAME, "#fff", 40, "center", s_oStage);
-        _oButPractice.addEventListener(ON_MOUSE_UP, this._onButPractice, this);
+        _aCardStartPos = [
+            {x: startX, y: startY},
+            {x: startX + _cardW + spacingX, y: startY},
+            {x: startX, y: startY + _cardH + spacingY},
+            {x: startX + _cardW + spacingX, y: startY + _cardH + spacingY}
+        ];
 
-        _pStartPosButOffline = {x: CANVAS_WIDTH/2, y: iStartY + 90};
-        _oButOffline = new CTextButton(_pStartPosButOffline.x, _pStartPosButOffline.y, oSpriteBtn, "1V1 OFFLINE", FONT_GAME, "#fff", 40, "center", s_oStage);
-        _oButOffline.addEventListener(ON_MOUSE_UP, this._onButOffline, this);
-
-        _pStartPosButOnline = {x: CANVAS_WIDTH/2, y: iStartY + 180};
-        _oButOnline = new CTextButton(_pStartPosButOnline.x, _pStartPosButOnline.y, oSpriteBtn, "1V1 ONLINE", FONT_GAME, "#fff", 40, "center", s_oStage);
-        _oButOnline.addEventListener(ON_MOUSE_UP, this._onButOnline, this);
-
-        _pStartPosButTournament = {x: CANVAS_WIDTH/2, y: iStartY + 270};
-        _oButTournament = new CTextButton(_pStartPosButTournament.x, _pStartPosButTournament.y, oSpriteBtn, "TOURNAMENTS", FONT_GAME, "#fff", 40, "center", s_oStage);
-        _oButTournament.addEventListener(ON_MOUSE_UP, this._onButTournament, this);
+        _oButPractice = this._createCardButton(_aCardStartPos[0].x, _aCardStartPos[0].y, "SOLO PRACTICE", this._onButPractice);
+        _oButOffline = this._createCardButton(_aCardStartPos[1].x, _aCardStartPos[1].y, "1V1 OFFLINE", this._onButOffline);
+        _oButOnline = this._createCardButton(_aCardStartPos[2].x, _aCardStartPos[2].y, "1V1 ONLINE", this._onButOnline);
+        _oButTournament = this._createCardButton(_aCardStartPos[3].x, _aCardStartPos[3].y, "TOURNAMENTS", this._onButTournament);
 
         // Audio toggle
         if(DISABLE_SOUND_MOBILE === false || s_bMobile === false){
@@ -104,10 +101,14 @@ function CMenu(){
 
     this.unload = function(){
         _oButCredits.unload();
-        _oButPractice.unload();
-        _oButOffline.unload();
-        _oButOnline.unload();
-        _oButTournament.unload();
+        _oButPractice.removeAllEventListeners();
+        _oButOffline.removeAllEventListeners();
+        _oButOnline.removeAllEventListeners();
+        _oButTournament.removeAllEventListeners();
+        s_oStage.removeChild(_oButPractice);
+        s_oStage.removeChild(_oButOffline);
+        s_oStage.removeChild(_oButOnline);
+        s_oStage.removeChild(_oButTournament);
 
         if(DISABLE_SOUND_MOBILE === false || s_bMobile === false){
             _oAudioToggle.unload();
@@ -131,10 +132,34 @@ function CMenu(){
             _oButFullscreen.setPosition(_pStartPosFullscreen.x + s_iOffsetX, _pStartPosFullscreen.y + s_iOffsetY);
         }
         _oButCredits.setPosition(_pStartPosCredits.x + s_iOffsetX, _pStartPosCredits.y + s_iOffsetY);
-        _oButPractice.setPosition(_pStartPosButPractice.x, _pStartPosButPractice.y - s_iOffsetY);
-        _oButOffline.setPosition(_pStartPosButOffline.x, _pStartPosButOffline.y - s_iOffsetY);
-        _oButOnline.setPosition(_pStartPosButOnline.x, _pStartPosButOnline.y - s_iOffsetY);
-        _oButTournament.setPosition(_pStartPosButTournament.x, _pStartPosButTournament.y - s_iOffsetY);
+    var aCards = [_oButPractice, _oButOffline, _oButOnline, _oButTournament];
+    for (var i = 0; i < _aCardStartPos.length; i++) {
+        aCards[i].x = _aCardStartPos[i].x + s_iOffsetX;
+        aCards[i].y = _aCardStartPos[i].y + s_iOffsetY;
+    }
+    };
+
+    this._createCardButton = function(iX, iY, szLabel, cb){
+        var oContainer = new createjs.Container();
+        oContainer.x = iX;
+        oContainer.y = iY;
+        oContainer.regX = _cardW / 2;
+        oContainer.regY = _cardH / 2;
+
+        var oBg = new createjs.Shape();
+        oBg.graphics.beginFill('#1e1e1e').drawRoundRect(-_cardW/2, -_cardH/2, _cardW, _cardH, 20);
+
+        var oText = new createjs.Text(szLabel, '40px ' + FONT_GAME, '#fff');
+        oText.textAlign = 'center';
+        oText.textBaseline = 'middle';
+
+        oContainer.addChild(oBg, oText);
+        oContainer.cursor = 'pointer';
+        oContainer.on('mousedown', function(){ oContainer.scaleX = oContainer.scaleY = 0.95; });
+        oContainer.on('pressup', function(){ oContainer.scaleX = oContainer.scaleY = 1; playSound('click',1,false); cb.call(s_oMenu); });
+
+        s_oStage.addChild(oContainer);
+        return oContainer;
     };
 
     this._onButPractice = function(){

--- a/js/ctl_utils.js
+++ b/js/ctl_utils.js
@@ -134,44 +134,17 @@ function sizeHandler() {
         _checkOrientation(w,h);
     }
 
-    // Use same scaling for all devices
-    var multiplier = Math.min((h / CANVAS_HEIGHT), (w / CANVAS_WIDTH));
+    // Scale to cover the entire screen without black bars
+    var multiplier = Math.max((h / CANVAS_HEIGHT), (w / CANVAS_WIDTH));
     var destW = Math.round(CANVAS_WIDTH * multiplier);
     var destH = Math.round(CANVAS_HEIGHT * multiplier);
-
-    //var iAdd = 0;
-   // if (destH < h){
-   //     iAdd = h-destH;
-   //     destH += iAdd;
-   //     destW += iAdd*(CANVAS_WIDTH/CANVAS_HEIGHT);
-   // }else  if (destW < w){
-   //     iAdd = w-destW;
-   //     destW += iAdd;
-   //     destH += iAdd*(CANVAS_HEIGHT/CANVAS_WIDTH);
-   // }
 
     var fOffsetY = ((h / 2) - (destH / 2));
     var fOffsetX = ((w / 2) - (destW / 2));
     var fGameInverseScaling = (CANVAS_WIDTH/destW);
 
-    if( fOffsetX*fGameInverseScaling < -EDGEBOARD_X ||  
-        fOffsetY*fGameInverseScaling < -EDGEBOARD_Y ){
-        multiplier = Math.min( h / (CANVAS_HEIGHT-(EDGEBOARD_Y*2)), w / (CANVAS_WIDTH-(EDGEBOARD_X*2)));
-        destW = Math.round(CANVAS_WIDTH * multiplier);
-        destH = Math.round(CANVAS_HEIGHT * multiplier);
-        fOffsetY = ( h - destH ) / 2;
-        fOffsetX = ( w - destW ) / 2;
-    }
-
     s_iOffsetX = (-1*fOffsetX * fGameInverseScaling);
     s_iOffsetY = (-1*fOffsetY * fGameInverseScaling);
-
-    if(fOffsetY >= 0 ){
-        s_iOffsetY = 0;
-    }
-    if(fOffsetX >= 0 ){
-        s_iOffsetX = 0;
-    }
 
     if(s_oGame !== null){
         s_oGame.refreshButtonPos( );

--- a/js/settings.js
+++ b/js/settings.js
@@ -218,7 +218,7 @@ STARTING_RACK_POS[GAME_MODE_TIME] = [
                     
 var RECT_COLLISION = new createjs.Rectangle( 124,117,1037,483);
 var MAX_SPIN_VALUE = 50;
-var K_IMPACT_BALL    = 0.97;	
+var K_IMPACT_BALL    = 0.99; // higher value for more realistic collisions
 var K_FRICTION       = 0.985;
 var K_MIN_FORCE      = 0.016;
 var MAX_POWER_SHOT = 200;


### PR DESCRIPTION
## Summary
- scale canvas to fill screen and switch background images via body classes
- redesign main menu with rounded card buttons and grid layout
- tweak physics for more realistic ball collisions

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68910651718c83279b166fd62461ea11