### PR TITLE
Center menu cards and remove background overlap

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -16,11 +16,11 @@ body{
 }
 
 body.menu{
-    background-image: url('../sprites/bg_menu.jpg');
+    background-image: none;
 }
 
 body.game{
-    background-image: url('../sprites/bg_game.jpg');
+    background-image: none;
 }
 
 *, *:before, *:after {

--- a/js/CMenu.js
+++ b/js/CMenu.js
@@ -28,8 +28,9 @@ function CMenu(){
         var spacingY = 40;
         var totalWidth = _cardW * 2 + spacingX;
         var totalHeight = _cardH * 2 + spacingY;
-        var startX = (CANVAS_WIDTH - totalWidth) / 2;
-        var startY = CANVAS_HEIGHT - totalHeight - 100;
+        // Center the first card horizontally and anchor the grid near the bottom
+        var startX = (CANVAS_WIDTH - totalWidth) / 2 + _cardW / 2;
+        var startY = CANVAS_HEIGHT - totalHeight - 100 + _cardH / 2;
 
         _aCardStartPos = [
             {x: startX, y: startY},


### PR DESCRIPTION
## Summary
- Correct menu card positioning so four cards are centered near the bottom
- Remove menu/game body background images to avoid mobile overlap

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689126dcbdf08327866aa2b38e17069f