### PR TITLE
Improve menu layout and player ball tracking

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -13,6 +13,7 @@ body{
     background-repeat: no-repeat;
     background-position: center;
     background-size: cover;
+    background-attachment: fixed;
 }
 
 body.menu{

--- a/js/CGame.js
+++ b/js/CGame.js
@@ -9,6 +9,7 @@ function CGame(){
     var _oInterface;
     var _oTable;
     var _oContainerGame;
+    var _oBg;
     var _oContainerTable;
     var _oContainerInterface;
     
@@ -48,9 +49,14 @@ function CGame(){
         
         _oContainerGame = new createjs.Container();
         s_oStage.addChild(_oContainerGame);
-        
-        var oBg = createBitmap(s_oSpriteLibrary.getSprite("bg_game"));
-        _oContainerGame.addChild(oBg);
+
+        var oSpriteBg = s_oSpriteLibrary.getSprite("bg_game");
+        _oBg = createBitmap(oSpriteBg);
+        _oBg.regX = oSpriteBg.width/2;
+        _oBg.regY = oSpriteBg.height/2;
+        _oBg.x = CANVAS_WIDTH/2;
+        _oBg.y = CANVAS_HEIGHT/2;
+        _oContainerGame.addChild(_oBg);
 
         _oContainerTable = new createjs.Container();
         _oContainerGame.addChild(_oContainerTable);
@@ -284,13 +290,16 @@ function CGame(){
     };
     
     this.refreshButtonPos = function(){
+        _oBg.x = CANVAS_WIDTH/2 + s_iOffsetX;
+        _oBg.y = CANVAS_HEIGHT/2 + s_iOffsetY;
+
         _oInterface.refreshButtonPos();
         _oPlayer1.refreshButtonPos();
         _oPlayer2.refreshButtonPos();
         _oInputController.refreshOffsetPos();
-        
+
         _oCointainerShotPowerBarInput.x = _oContainerShotPowerBar.x = s_iOffsetX * 0.5;
-        
+
         if(_oInteractiveHelp){
             _oInteractiveHelp.refreshButtonsPos();
         }
@@ -333,15 +342,32 @@ function CGame(){
         _oGameState.assignSuits(iBallNumber);
         this.setBallInInterface(_oGameState.getSuitForPlayer(1));
     };
-    
+
     this.setBallInInterface = function(szSuites1) {
             if (szSuites1 == "solid") {
                     _oPlayer1.setBall(2);
                     _oPlayer2.setBall(15);
+                    _oPlayer1.setSuit("solid");
+                    _oPlayer2.setSuit("stripes");
             }else {
                     _oPlayer1.setBall(15);
-                    _oPlayer2.setBall(2);    
+                    _oPlayer2.setBall(2);
+                    _oPlayer1.setSuit("stripes");
+                    _oPlayer2.setSuit("solid");
             }
+    };
+
+    this.ballPotted = function(iBall){
+        if(!_oGameState.isSuitAssigned()){
+            return;
+        }
+
+        var szSuit1 = _oGameState.getSuitForPlayer(1);
+        if ((szSuit1 === "solid" && iBall < 8) || (szSuit1 === "stripes" && iBall > 8)) {
+            _oPlayer1.removeBall(iBall);
+        } else if (iBall !== 8) {
+            _oPlayer2.removeBall(iBall);
+        }
     };
     
     this.isLegalShotFor8Ball = function(iBall,iNumBallToPot) {

--- a/js/CMenu.js
+++ b/js/CMenu.js
@@ -20,7 +20,12 @@ function CMenu(){
 
     this._init = function(){
         // Background
-        _oBg = createBitmap(s_oSpriteLibrary.getSprite('bg_menu'));
+        var oSpriteBg = s_oSpriteLibrary.getSprite('bg_menu');
+        _oBg = createBitmap(oSpriteBg);
+        _oBg.regX = oSpriteBg.width / 2;
+        _oBg.regY = oSpriteBg.height / 2;
+        _oBg.x = CANVAS_WIDTH / 2;
+        _oBg.y = CANVAS_HEIGHT / 2;
         s_oStage.addChild(_oBg);
 
         // Card layout buttons
@@ -135,11 +140,15 @@ function CMenu(){
             _oButFullscreen.setPosition(_pStartPosFullscreen.x + s_iOffsetX, _pStartPosFullscreen.y + s_iOffsetY);
         }
         _oButCredits.setPosition(_pStartPosCredits.x + s_iOffsetX, _pStartPosCredits.y + s_iOffsetY);
-    var aCards = [_oButPractice, _oButOffline, _oButOnline, _oButTournament];
-    for (var i = 0; i < _aCardStartPos.length; i++) {
-        aCards[i].x = _aCardStartPos[i].x + s_iOffsetX;
-        aCards[i].y = _aCardStartPos[i].y + s_iOffsetY;
-    }
+
+        var aCards = [_oButPractice, _oButOffline, _oButOnline, _oButTournament];
+        for (var i = 0; i < _aCardStartPos.length; i++) {
+            aCards[i].x = _aCardStartPos[i].x + s_iOffsetX;
+            aCards[i].y = _aCardStartPos[i].y + s_iOffsetY * 0.5;
+        }
+
+        _oBg.x = CANVAS_WIDTH / 2 + s_iOffsetX;
+        _oBg.y = CANVAS_HEIGHT / 2 + s_iOffsetY;
     };
 
     this._createCardButton = function(iX, iY, szLabel, cb){

--- a/js/CPlayerGUI.js
+++ b/js/CPlayerGUI.js
@@ -4,8 +4,12 @@ function CPlayerGUI(iX,iY,szName,oParentContainer){
     var _szName;
     var _oTextName;
     var _oBall;
+    var _oBallSpriteSheet;
+    var _oBallsContainer;
+    var _aBallIcons;
     var _oHighlight;
     var _oContainer;
+    var _oSpriteBg;
     var _oParentContainer = oParentContainer;
     
     this._init = function(iX,iY,szName){
@@ -18,9 +22,10 @@ function CPlayerGUI(iX,iY,szName,oParentContainer){
         _oParentContainer.addChild(_oContainer);
         
         var oSpriteBG = s_oSpriteLibrary.getSprite("player_gui");
+        _oSpriteBg = oSpriteBG;
         var oBg = createBitmap(oSpriteBG);
         _oContainer.addChild(oBg);
-        
+
          var oSpriteHighlight =s_oSpriteLibrary.getSprite("highlight_player");
          _oHighlight = createBitmap(oSpriteHighlight);
          _oHighlight.alpha = 0;
@@ -38,16 +43,16 @@ function CPlayerGUI(iX,iY,szName,oParentContainer){
                     true, true, false,
                     false );
         
-        var oData = {   
-                        images: [s_oSpriteLibrary.getSprite("balls")], 
+        var oData = {
+                        images: [s_oSpriteLibrary.getSprite("balls")],
                         // width, height & registration point of each sprite
-                        frames: {width: BALL_DIAMETER, height: BALL_DIAMETER, regX: BALL_DIAMETER/2, regY: BALL_DIAMETER/2}, 
+                        frames: {width: BALL_DIAMETER, height: BALL_DIAMETER, regX: BALL_DIAMETER/2, regY: BALL_DIAMETER/2},
                         animations: {ball_0:0,ball_1:1,ball_2:2,ball_3:3,ball_4:4,ball_5:5,ball_6:6,ball_7:7,ball_8:8,ball_9:9
                                     ,ball_10:10,ball_11:11,ball_12:12,ball_13:13,ball_14:14,ball_15:15}
                    };
-                   
-         var oSpriteSheet = new createjs.SpriteSheet(oData);
-         _oBall = createSprite(oSpriteSheet,"ball_0",BALL_DIAMETER/2,BALL_DIAMETER/2,BALL_DIAMETER,BALL_DIAMETER);
+
+         _oBallSpriteSheet = new createjs.SpriteSheet(oData);
+         _oBall = createSprite(_oBallSpriteSheet,"ball_0",BALL_DIAMETER/2,BALL_DIAMETER/2,BALL_DIAMETER,BALL_DIAMETER);
          _oBall.x = oSpriteBG.width - BALL_DIAMETER - 20;
          _oBall.y = oSpriteBG.height/2;
          _oBall.visible = false;
@@ -69,6 +74,37 @@ function CPlayerGUI(iX,iY,szName,oParentContainer){
     this.setBall = function(iBall){
         this.setBallVisible(true);
         _oBall.gotoAndStop("ball_"+iBall);
+    };
+
+    this.setSuit = function(szSuit){
+        if(_oBallsContainer){
+            _oContainer.removeChild(_oBallsContainer);
+        }
+        _oBallsContainer = new createjs.Container();
+        _oContainer.addChild(_oBallsContainer);
+        _aBallIcons = {};
+
+        var aBalls = (szSuit === "solid") ? [1,2,3,4,5,6,7] : [9,10,11,12,13,14,15];
+        var iScale = 0.4;
+        var iSpacing = BALL_DIAMETER * iScale + 5;
+        var iStartX = _oSpriteBg.width/2 - (aBalls.length * iSpacing)/2 + (BALL_DIAMETER * iScale)/2;
+
+        for(var i=0; i<aBalls.length; i++){
+            var iBallNum = aBalls[i];
+            var oIcon = createSprite(_oBallSpriteSheet, "ball_"+iBallNum, BALL_DIAMETER/2, BALL_DIAMETER/2, BALL_DIAMETER, BALL_DIAMETER);
+            oIcon.scaleX = oIcon.scaleY = iScale;
+            oIcon.x = iStartX + i * iSpacing;
+            oIcon.y = _oSpriteBg.height + 10 + BALL_DIAMETER * iScale/2;
+            _oBallsContainer.addChild(oIcon);
+            _aBallIcons[iBallNum] = oIcon;
+        }
+    };
+
+    this.removeBall = function(iBall){
+        if(_aBallIcons && _aBallIcons[iBall]){
+            _oBallsContainer.removeChild(_aBallIcons[iBall]);
+            delete _aBallIcons[iBall];
+        }
     };
     
     this.highlight = function(){

--- a/js/CTable.js
+++ b/js/CTable.js
@@ -305,6 +305,7 @@ function CTable(oParentContainer){
                             _aBallsInHoles.push(oBall.getNumber());
                     }
                     _aBallsInHoleInCurShot.push(oBall.getNumber());
+                    s_oGame.ballPotted(oBall.getNumber());
 
                     //_iShotPoints=_parent.checkBonus(m_iShotPoints);
             }else {
@@ -319,6 +320,7 @@ function CTable(oParentContainer){
 
                     _aBallsInHoles.push(oBall.getNumber());
                     _aBallsInHoleInCurShot.push(oBall.getNumber());
+                    s_oGame.ballPotted(oBall.getNumber());
 
             }else {
                 _bCueBallInHole = true;


### PR DESCRIPTION
## Summary
- Anchor menu cards near the bottom center and center backgrounds for consistent layout on all screens
- Show each player's ball suit and remaining balls, updating as balls are potted
- Ensure backgrounds scale on mobile with fixed attachment

## Testing
- `node --check js/CMenu.js`
- `node --check js/CPlayerGUI.js`
- `node --check js/CGame.js`
- `node --check js/CTable.js`
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6891312dd5f483279d79b35f0ea33586