### PR TITLE
fix: persist pre-suit potted balls for GUI

### DIFF
--- a/js/CGame.js
+++ b/js/CGame.js
@@ -30,7 +30,7 @@ function CGame(){
         _bHoldStickCommand = false;
         _iDirStickCommand = 1;
         _iDirStickSpeedCommand = COMMAND_STICK_START_SPEED;
-        _aPottedBallsBeforeAssign = [];
+        _aPottedBallsBeforeAssign = _oGameState.getPottedBallsBeforeAssign();
         
         switch(s_iGameMode) {
             case GAME_MODE_NINE: {
@@ -348,6 +348,7 @@ function CGame(){
             this.ballPotted(_aPottedBallsBeforeAssign[i]);
         }
         _aPottedBallsBeforeAssign = [];
+        _oGameState.clearPottedBallsBeforeAssign();
     };
 
     this.setBallInInterface = function(szSuites1) {
@@ -367,6 +368,7 @@ function CGame(){
     this.ballPotted = function(iBall){
         if(!_oGameState.isSuitAssigned()){
             _aPottedBallsBeforeAssign.push(iBall);
+            _oGameState.addPottedBallBeforeAssign(iBall);
             return;
         }
 

--- a/js/GameState.js
+++ b/js/GameState.js
@@ -4,6 +4,7 @@ function GameState(){
     var _aSuitePlayer;
     var _iScore;
     var _iWinStreak;
+    var _aPottedBallsBeforeAssign;
 
     this.reset = function(){
         _iCurTurn = 1;
@@ -11,6 +12,7 @@ function GameState(){
         _aSuitePlayer = [];
         _iScore = 0;
         _iWinStreak = 0;
+        _aPottedBallsBeforeAssign = [];
     };
 
     this.changeTurn = function(){
@@ -98,13 +100,26 @@ function GameState(){
         return _bSuitAssigned;
     };
 
+    this.addPottedBallBeforeAssign = function(iBall){
+        _aPottedBallsBeforeAssign.push(iBall);
+    };
+
+    this.getPottedBallsBeforeAssign = function(){
+        return _aPottedBallsBeforeAssign.slice();
+    };
+
+    this.clearPottedBallsBeforeAssign = function(){
+        _aPottedBallsBeforeAssign = [];
+    };
+
     this.toJSON = function(){
         return {
             curTurn: _iCurTurn,
             suitAssigned: _bSuitAssigned,
             suites: _aSuitePlayer,
             score: _iScore,
-            winStreak: _iWinStreak
+            winStreak: _iWinStreak,
+            pottedBallsBeforeAssign: _aPottedBallsBeforeAssign
         };
     };
 


### PR DESCRIPTION
## Summary
- track balls potted before suit assignment in game state
- replay buffered potted balls when suits are decided so GUI updates accurately

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68913c09c05c8327937875ccbb3af27e