### PR TITLE
Show assigned balls and allow ball placement after timeout

### DIFF
--- a/js/CGame.js
+++ b/js/CGame.js
@@ -258,8 +258,10 @@ function CGame(){
             _iTurnTime--;
             _oTimerText.refreshText(_iTurnTime);
             if(_iTurnTime <= 0){
+                // treat timeout as a fault: opponent gets ball in hand
                 s_oGame.stopTurnTimer();
-                s_oGame.changeTurn(false);
+                s_oTable.respotCueBall();
+                s_oGame.changeTurn(true);
             }
         },1000);
     };

--- a/js/CPlayerGUI.js
+++ b/js/CPlayerGUI.js
@@ -88,19 +88,19 @@ function CPlayerGUI(iX,iY,szName,oParentContainer){
         var iScale = 0.4;
         var iSpacing = BALL_DIAMETER * iScale + 5;
         var iStartX = _oSpriteBg.width/2 - (aBalls.length * iSpacing)/2 + (BALL_DIAMETER * iScale)/2;
+        var iYPos = _oSpriteBg.height - BALL_DIAMETER * iScale/2 - 10;
 
         for(var i=0; i<aBalls.length; i++){
             var iBallNum = aBalls[i];
             var oIcon = createSprite(_oBallSpriteSheet, "ball_"+iBallNum, BALL_DIAMETER/2, BALL_DIAMETER/2, BALL_DIAMETER, BALL_DIAMETER);
             oIcon.scaleX = oIcon.scaleY = iScale;
             oIcon.x = iStartX + i * iSpacing;
-            oIcon.y = _oSpriteBg.height + 10 + BALL_DIAMETER * iScale/2;
+            oIcon.y = iYPos;
             _oBallsContainer.addChild(oIcon);
             _aBallIcons[iBallNum] = oIcon;
         }
 
-        var szLabel = (szSuit === "solid") ? "SOLIDS" : "STRIPES";
-        _oTextName.refreshText(_szName + " - " + szLabel);
+        _oTextName.refreshText(_szName);
     };
 
     this.removeBall = function(iBall){


### PR DESCRIPTION
## Summary
- Display each player's assigned balls as icons beneath their name instead of SOLIDS/STRIPES text
- On timeout, treat it as a foul and give the opponent ball-in-hand

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689144533c7c8327bd3bfdb132247a43